### PR TITLE
Add GitHub action to create plugin file

### DIFF
--- a/.github/workflows/make-plugin-file.yaml
+++ b/.github/workflows/make-plugin-file.yaml
@@ -5,20 +5,19 @@ on:
       - master
 jobs:
   create_plugin_file:
-    runs-on: ubuntu-20.04
+    runs-on: "ubuntu-latest"
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v2
-      - name: zip up files
-        run: zip -r wordscounter.plugin . -x *.git*
       - name: Get current git hash
         id: current-hash
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: zip up files
+        run: zip -r wordscounter-${{ steps.current-hash.outputs.sha_short }}.plugin . -x *.git*
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "v${{ steps.current-hash.outputs.sha_short }}"
-          title: "Compiled-at-${{ steps.current-hash.outputs.sha_short }}"
+          title: "Compiled from ${{ steps.current-hash.outputs.sha_short }}"
           prerelease: true
-          files: "wordscounter.plugin"
-          
+          files: "wordscounter-${{ steps.current-hash.outputs.sha_short }}.plugin"

--- a/.github/workflows/make-plugin-file.yaml
+++ b/.github/workflows/make-plugin-file.yaml
@@ -1,5 +1,8 @@
 name: create plugin file and publish it as release
-on: [push]
+on:
+  push:
+    branches:
+      - master
 jobs:
   create_plugin_file:
     runs-on: ubuntu-20.04

--- a/.github/workflows/make-plugin-file.yaml
+++ b/.github/workflows/make-plugin-file.yaml
@@ -1,0 +1,24 @@
+name: create plugin file and publish it as release
+on: [push]
+jobs:
+  create_plugin_file:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: zip up files
+        run: zip -r wordscounter.plugin . -x *.git*
+      - name: Get current time
+        uses: 1466587594/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DD_HHmm
+          utcOffset: "+02:00"
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "v${{ steps.current-time.outputs.formattedTime }}"
+          title: "Compiled-at-${{ steps.current-time.outputs.formattedTime }}"
+          prerelease: true
+          files: "wordscounter.plugin"
+          

--- a/.github/workflows/make-plugin-file.yaml
+++ b/.github/workflows/make-plugin-file.yaml
@@ -11,17 +11,14 @@ jobs:
         uses: actions/checkout@v2
       - name: zip up files
         run: zip -r wordscounter.plugin . -x *.git*
-      - name: Get current time
-        uses: 1466587594/get-current-time@v2
-        id: current-time
-        with:
-          format: YYYY-MM-DD_HHmm
-          utcOffset: "+02:00"
+      - name: Get current git hash
+        id: current-hash
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "v${{ steps.current-time.outputs.formattedTime }}"
-          title: "Compiled-at-${{ steps.current-time.outputs.formattedTime }}"
+          automatic_release_tag: "v${{ steps.current-hash.outputs.sha_short }}"
+          title: "Compiled-at-${{ steps.current-hash.outputs.sha_short }}"
           prerelease: true
           files: "wordscounter.plugin"
           


### PR DESCRIPTION
I just got a bit frustrated because I needed to quickly install this plugin and it took me several tries before I understood how to pack a plugin file correctly, so it would install. So I support that you solve #9 or [ONLYOFFICE/plugin-highlightcode#37](https://github.com/ONLYOFFICE/plugin-highlightcode/issues/37) quickly and I also wanted to offer a simple solution.

This PR introduces a GitHub action workflow to zip up the files in the correct way and publish them as a release. Individual releases can be customised by editing them or they can be removed. You can link the plugin file in the ReadMe to the latest release automatically like this [https://github.com/JBGruber/plugin-wordscounter/releases/latest/download/wordscounter.plugin](https://github.com/JBGruber/plugin-wordscounter/releases/latest/download/wordscounter.plugin). 

Currently, I have the workflow set up to use the time of "compilation" for the title of the release and the flag `prerelease:` is set to `true`, which means the prerelease box needs to be manually unticked for a release to be accessible through the link. Both can be customised if you are interested.